### PR TITLE
Add dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,19 @@
+FROM debian:11
+
+WORKDIR /app/net6.0
+
+COPY ubuntu-latest.zip .
+
+RUN apt update \
+  && apt install -y wget unzip \
+  && wget https://packages.microsoft.com/config/ubuntu/22.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb \
+  && dpkg -i packages-microsoft-prod.deb \
+  && apt update \
+  && apt install -y dotnet-runtime-6.0 \
+  && unzip ubuntu-latest.zip -d /app \
+  && chmod +x /app/net6.0/JboxWebdav.ConsoleApp \
+  && rm packages-microsoft-prod.deb \
+  && rm ubuntu-latest.zip \
+  && apt remove -y wget unzip
+
+CMD ["./JboxWebdav.ConsoleApp"]


### PR DESCRIPTION
- 构建：
  ```bash
  docker build . -t jbox-webdav
  ```
- 使用：
  因为目前需要在命令行交互式地输入用户名密码，所以容器启动分为两个部分，第一步输入用户名密码后直接退出，第二步使其在后台运行
  ```bash
  docker run --rm -v /path/to/cookie:/app/net6.0/JboxWebdav -it jbox-webdav
  docker run -p 65472:65472 -v /path/to/cookie:/app/net6.0/JboxWebdav -dt jbox-webdav
  ```